### PR TITLE
Bug fix

### DIFF
--- a/edit/src/source/github.js
+++ b/edit/src/source/github.js
@@ -70,6 +70,12 @@ module.exports = function(context, config) {
 
       var repo = getUpstream();
       repo.fork()
+      .then((forked_repo) => {
+        var new_reponame = forked_repo.data['name']
+        var github = getGitHub();
+        var origin = github.getRepo(context.storage.get('github_username'), new_reponame);
+        return origin.updateRepository({name : 'mapseries-data'})
+      })
       .catch((err) => {
         window.clearInterval(timer);
         reject(err);


### PR DESCRIPTION
The bug: When user's mapseries-data repository is not synchronized with the one from moravianlibrary, the application removes and creates a new one with a new name mapseries-data-1 (which is github's standard behavior when deleting and forking the same repository again, when it just existed).
The fix: After the application creates a new repository with a new name, rename it back to mapseries-data.